### PR TITLE
Fix issue with skipped GitHub builds

### DIFF
--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -61,6 +61,7 @@ pub enum BuildStatusViewModel {
     Running,
     Canceled,
     Queued,
+    Skipped,
 }
 
 impl From<&Build> for BuildViewModel {
@@ -91,6 +92,7 @@ impl From<&BuildStatus> for BuildStatusViewModel {
             BuildStatus::Running => BuildStatusViewModel::Running,
             BuildStatus::Canceled => BuildStatusViewModel::Canceled,
             BuildStatus::Queued => BuildStatusViewModel::Queued,
+            BuildStatus::Skipped => BuildStatusViewModel::Skipped,
         }
     }
 }

--- a/src/builds.rs
+++ b/src/builds.rs
@@ -134,6 +134,7 @@ pub enum BuildStatus {
     Running,
     Canceled,
     Queued,
+    Skipped,
 }
 
 impl BuildStatus {
@@ -145,6 +146,7 @@ impl BuildStatus {
             BuildStatus::Running => false,
             BuildStatus::Canceled => false,
             BuildStatus::Queued => false,
+            BuildStatus::Skipped => false,
         }
     }
 }

--- a/src/providers/collectors/github/client.rs
+++ b/src/providers/collectors/github/client.rs
@@ -129,6 +129,7 @@ impl GitHubWorkflowRun {
                     "success" => Ok(BuildStatus::Success),
                     "cancelled" => Ok(BuildStatus::Canceled),
                     "failure" => Ok(BuildStatus::Failed),
+                    "skipped" => Ok(BuildStatus::Skipped),
                     _ => Ok(BuildStatus::Failed),
                 },
             },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.11.0",
+  "version": "0.13.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/web/src/components/Build.vue
+++ b/web/src/components/Build.vue
@@ -104,4 +104,9 @@ export default {
 .queued {
   background-color: #999999;
 }
+
+.skipped {
+  background-color: #999999;
+}
+
 </style>

--- a/web/src/components/StatusIcon.vue
+++ b/web/src/components/StatusIcon.vue
@@ -31,6 +31,7 @@ export default {
               case "Running": return "running";
               case "Canceled": return "stop-circle";
               case "Queued": return "clock";
+              case "Skipped": return "stop-circle";
               default: return "question-circle"
 
           }


### PR DESCRIPTION
Skipped GitHub builds are currently shown as failed in the UI. This PR adds a new state for skipped builds and makes sure that skipped GitHub builds are displayed correctly in the UI.

Closes #65