### PR TITLE
Duck collector: Add view support

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -410,6 +410,9 @@ pub struct DuckConfiguration {
     /// # The Duck server URL
     #[serde(rename = "serverUrl")]
     pub server_url: String,
+    /// # The view to get builds from
+    #[serde(default)]
+    pub view: Option<String>,
 }
 
 ///////////////////////////////////////////////////////////

--- a/src/providers/collectors/duck/client.rs
+++ b/src/providers/collectors/duck/client.rs
@@ -7,12 +7,14 @@ use crate::DuckResult;
 
 pub struct DuckClient {
     pub server_url: String,
+    pub view: Option<String>,
 }
 
 impl DuckClient {
     pub fn new(config: &DuckConfiguration) -> Self {
         Self {
             server_url: config.server_url.clone(),
+            view: config.view.clone(),
         }
     }
 
@@ -26,7 +28,14 @@ impl DuckClient {
     }
 
     pub fn get_builds(&self, client: &impl HttpClient) -> DuckResult<Vec<DuckBuild>> {
-        let url = format!("{}/api/builds", owner = self.server_url,);
+        let url = match &self.view {
+            Some(view) => format!(
+                "{owner}/api/builds/view/{view}",
+                owner = self.server_url,
+                view = view
+            ),
+            None => format!("{owner}/api/builds", owner = self.server_url),
+        };
 
         let body = self.send_get_request(client, url)?;
         Ok(serde_json::from_str(&body[..])?)

--- a/src/providers/collectors/duck/test_data/view.json
+++ b/src/providers/collectors/duck/test_data/view.json
@@ -1,0 +1,16 @@
+[
+    {
+        "id": 1619989489999387859,
+        "provider": "GitHub",
+        "collector": "duck_other",
+        "project": "spectresystems/duck",
+        "build": "ci.yaml",
+        "branch": "setup-docker-for-local-development",
+        "buildId": "58880314",
+        "buildNumber": "24",
+        "started": 1584617069,
+        "finished": 1584617318,
+        "url": "https://github.com/spectresystems/duck/actions/runs/58880314",
+        "status": "Success"
+    }
+]


### PR DESCRIPTION
Adds view support for the Duck collector so an individual view
can be fetched instead of all builds from the Duck server.

Closes #67