### PR TITLE
Temporarily disable PurgeCSS plugin

### DIFF
--- a/web/postcss.config.js
+++ b/web/postcss.config.js
@@ -17,8 +17,8 @@ module.exports = {
   plugins: [
     require('tailwindcss'),
     require('autoprefixer'),
-    ...process.env.NODE_ENV === 'production'
-      ? [purgecss]
-      : []
+    // ...process.env.NODE_ENV === 'production'
+    //   ? [purgecss]
+    //   : []
   ]
 }


### PR DESCRIPTION
The PurgeCSS plugin seems to purge more than it should, so temporarily disabling it until we can figure out what's causing the problem.

Closes #98
Closes #99