### PR TITLE
Remove 'Failed' from list of 'Running' statuses for Octopus Deploy

### DIFF
--- a/src/providers/collectors/octopus/mod.rs
+++ b/src/providers/collectors/octopus/mod.rs
@@ -171,7 +171,7 @@ impl OctopusDeployment {
         match &self.status[..] {
             "Success" => BuildStatus::Success,
             "Queued" => BuildStatus::Queued,
-            "Executing" | "Cancelling" | "Failed" | "" => BuildStatus::Running,
+            "Executing" | "Cancelling" | "" => BuildStatus::Running,
             "Canceled" => BuildStatus::Canceled,
             _ => BuildStatus::Failed,
         }


### PR DESCRIPTION
Fixes #108 